### PR TITLE
Added compliance satus NOT_AVAILABLE for deleted resources

### DIFF
--- a/Code/lambda_function.py
+++ b/Code/lambda_function.py
@@ -28,6 +28,8 @@ def get_compliance_and_severity(new_status):
     status = ['FAILED', 3.0, 30]
     if new_status == 'COMPLIANT':
         status = ['PASSED', 0, 0]
+    elif new_status == 'NOT_APPLICABLE':
+        status = ['NOT_AVAILABLE', 0, 0]
     return status
 
 


### PR DESCRIPTION
*Description of changes:*

Deleted resources have been shown as "Compliance Status: Failed" in Security Hub. Now they will be shown as "NOT_AVAILABLE".

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
